### PR TITLE
does this need to be uri encoded?

### DIFF
--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -49,9 +49,7 @@
             building
       - @profiles.each do |profile|
         %tr{:class => ("head" unless profile.opt_in.nil?)}
-          - require 'uri'
-          - @photo_link_dirty = "https://www2.library.ualberta.ca/2015assets/all-staff-photos/thumbs/"+profile.first_name.downcase+"-"+profile.last_name.downcase+".jpg"
-          - @photo_link = URI.encode_www_form_component(@photo_link_dirty)
+          - @photo_link = "https://www2.library.ualberta.ca/2015assets/all-staff-photos/thumbs/#{profile.first_name.downcase}-#{profile.last_name.downcase}.jpg"
           - @no_photo = "staff-photos/thumbs/none.jpg"
           %td.staff-images
             = link_to image_tag(@photo_link), profile_path(profile)

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,9 +1,7 @@
 .a-profile.extra-top-margin
   = link_to profiles_path, class: "staff-back" do
     <span class="glyphicon glyphicon-chevron-left"></span>  All Staff	
-  - require 'uri'
-  - @photo_link_dirty = "https://www2.library.ualberta.ca/2015assets/all-staff-photos/"+@profile.first_name.downcase+"-"+@profile.last_name.downcase+".jpg"
-  - @photo_link = URI.encode(@photo_link_dirty)
+  - @photo_link = "https://www2.library.ualberta.ca/2015assets/all-staff-photos/#{@profile.first_name.downcase}-#{@profile.last_name.downcase}.jpg"
   = image_tag(@photo_link, :class=>"a-photo img-responsive")
   %h2.fn
     %span.given-name


### PR DESCRIPTION
I don't think so.  `image_tag` calls `tag` which says

> The generated tag names and attributes are escaped by default. This can be disabled using escape.

https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag