### PR TITLE
Don't automatically disable submit button on press

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,11 @@ module HomeCms
     # Rails decided to deem Symbol safe
     # https://github.com/rails/rails/pull/45584
     config.active_record.yaml_column_permitted_classes = [Symbol]
+
+    # this is for the cms edit page preview and update buttons.  
+    # app/views/comfy/admin/cms/pages/_form.html.haml
+    # https://github.com/ualbertalib/library-cms/issues/378
+    # Behaviour changes when using Ruby 3.0 so can likely remove after that point.
+    config.action_view.automatically_disable_submit_tag = false
   end
 end


### PR DESCRIPTION
Jane Banks says,
> If I click "Preview" it shows the update, but then when I go back to the page, both the "Preview" and "Update Page" buttons are greyed out.

Before:
![image](https://user-images.githubusercontent.com/1220762/180258659-debd4f82-e986-4d9a-bf7f-2ae5e5be1da8.png)

After:
![image](https://user-images.githubusercontent.com/1220762/180258484-5ffee250-a26d-40e2-bbc3-a3a20c3a37b5.png)


Our comfy dependency changed the behaviour in their Ruby 3.0 update.

This fix may have unintended side effects on other pages where pressing submit should disable buttons but I'm not aware of any.

fixes #378 