### PR TITLE
upgrade bundler to resolve errors on ruby 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,4 +306,4 @@ DEPENDENCIES
   webpacker (~> 5.4)
 
 BUNDLED WITH
-   2.1.4
+   2.4.9


### PR DESCRIPTION
Was getting errors from bundler on ruby 2.7 so this PR is in preparation for that upgrade