### PR TITLE
Add editorconf file to help consistent coding styles for project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Noticed from a recent PRs I was getting diffs for spacing like newlines/trailing spaces.

We can use https://editorconfig.org/ to hopefully help prevent this. Stole the same editorconfig file from Jupiter and put it in here.