### PR TITLE
Force ActiveStorage to use minimagick as this is what we currently use in staging/production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,9 @@ module HomeCms
     # Behaviour changes when using Ruby 3.0 so can likely remove after that point.
     # TODO: Appears to still be an issue in Ruby 3.0, need to investigate this further.
     config.action_view.automatically_disable_submit_tag = false
+
+    # We currently use mini_magick for ActiveStorage. VIPS is now the default. So we need to explicitly specify this.
+    # Delete this line if we ever migrate to VIPS
+    config.active_storage.variant_processor = :mini_magick
   end
 end


### PR DESCRIPTION
When I removed Rails 7.0 defaults, it swapped us to the new default for ActiveStorage which is using VIPS.

We currently don't have libvips installed in staging/production so we are seeing some errors for this when I was testing `1.9.0` release on staging.

https://app.rollbar.com/a/ualbertalib/fix/item/library-cms/5

Let's force this to the previous default, which was `mini_magick`