### PR TITLE
Production environment needs to use proxy for rollbar, add configuration for this

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -55,12 +55,12 @@ Rollbar.configure do |config|
   # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
   # are optional.
   #
-  # config.proxy = {
-  #   host: 'http://some.proxy.server',
-  #   port: 80,
-  #   user: 'username_if_auth_required',
-  #   password: 'password_if_auth_required'
-  # }
+  config.proxy = {
+    host: Rails.application.secrets.rollbar_proxy_host,
+    port: Rails.application.secrets.rollbar_proxy_port,
+    user: Rails.application.secrets.rollbar_proxy_user,
+    password: Rails.application.secrets.rollbar_proxy_password
+  }
 
   # If you run your staging application instance in production environment then
   # you'll want to override the environment reported by `Rails.env` with an

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -26,4 +26,13 @@
 shared:
   cms_user: 'admin'
   cms_password: 'mysecretpassword'
+
+staging:
   rollbar_access_token: <%= ENV['ROLLBAR_ACCESS_TOKEN'] %>
+
+production:
+  rollbar_access_token: <%= ENV['ROLLBAR_ACCESS_TOKEN'] %>
+  rollbar_proxy_host: <%= ENV['ROLLBAR_PROXY_HOST'] %>
+  rollbar_proxy_port: <%= ENV['ROLLBAR_PROXY_PORT'] %>
+  rollbar_proxy_user: <%= ENV['ROLLBAR_PROXY_USER'] %>
+  rollbar_proxy_password: <%= ENV['ROLLBAR_PROXY_PASSWORD'] %>


### PR DESCRIPTION
Production environment is under a strict firewall where it can't talk to the outside world. We need rollbar to use the proxy server to properly send exceptions up to rollbar instead.

This adds a way to set the proxy config using secrets.yml which will be replaced with ansible. 