### PR TITLE
#519: Ignore ActionController::RoutingError exceptions 

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -31,6 +31,10 @@ Rollbar.configure do |config|
   # 'ignore' will cause the exception to not be reported at all.
   # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
   #
+  config.exception_level_filters.merge!({
+    'ActionController::RoutingError' => 'ignore'
+  })
+
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 


### PR DESCRIPTION
In the last 24 hours, we got almost 10k worth of `ActionController::RoutingError`.  At this rate, we are on pace to surpass our usage for this Month.

<img width="446" alt="image" src="https://github.com/ualbertalib/library-cms/assets/1930474/a53e018e-86cf-4b70-b769-a0756f381546">

We should ignore this for the time being.

We probably have enough data here that we can investigate a few of the issues people are having.

E.g: About 10% of the exception requests are for 
- https://www.library.ualberta.ca/apple-touch-icon.png
- https://www.library.ualberta.ca/apple-touch-icon-precomposed.png

Others appear to be perhaps bad links (mailto links? RSS links, etc)?