### PR TITLE
Revert "Bump listen from 3.8.0 to 3.9.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
 
-  gem 'listen', '>= 3.0.5', '< 3.10'
+  gem 'listen', '>= 3.0.5', '< 3.9'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring', '>= 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       ruby2_keywords
     erubi (1.12.0)
     execjs (2.9.1)
-    ffi (1.16.3)
+    ffi (1.15.5)
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
     globalid (1.2.1)
@@ -157,7 +157,7 @@ GEM
       thor (>= 0.14, < 2.0)
     kramdown (2.4.0)
       rexml
-    listen (3.9.0)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
@@ -319,7 +319,7 @@ DEPENDENCIES
   htmlentities
   image_processing (~> 1.12, >= 1.12.2)
   jbuilder (~> 2.11)
-  listen (>= 3.0.5, < 3.10)
+  listen (>= 3.0.5, < 3.9)
   mysql2 (~> 0.5.6)
   puma (~> 6.4)
   rails (~> 7.1.3)


### PR DESCRIPTION
Reverts ualbertalib/library-cms#549 in hopes to resolve an issue with the current build (1.9.5) failing on staging due to an error which seems to be related to the ffi gem bump (1.15.5 to 1.16.3.)