### PR TITLE
Remove ignores and add github actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,44 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: nokogiri
-    versions:
-    - 1.11.1
-    - 1.11.2
-  - dependency-name: listen
-    versions:
-    - 3.4.1
-    - 3.5.0
-  - dependency-name: bootsnap
-    versions:
-    - 1.6.0
-    - 1.7.0
-    - 1.7.1
-    - 1.7.2
-    - 1.7.3
-  - dependency-name: rails
-    versions:
-    - 6.1.1
-    - 6.1.2
-    - 6.1.2.1
-    - 6.1.3
-  - dependency-name: puma
-    versions:
-    - 5.2.0
-    - 5.2.1
-  - dependency-name: capybara
-    versions:
-    - 3.35.1
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-    time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@fortawesome/fontawesome-free"
-    versions:
-    - 5.15.2
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Saw we were ignoring certain gems (will have to dive deeper for why we are doing this), but these all seem like old versions (we on more newer versions now) or simple patch versions which should be fine to upgrade.

Also added GitHub actions to dependabot. And removed "time" config, as this is probably not useful 🤔 