### PR TITLE
Cleanup global variables in profiles controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,3 @@ Rails/BulkChangeTable:
 Rails/ThreeStateBooleanColumn:
   Exclude:
     - db/migrate/20181101154627_create_profiles.rb
-
-# Below are cops that are currently disabled, where we should fix in the future
-# TODO: Fix ProfilesController so we don't need to use global vars
-Style/GlobalVars:
-  Exclude:
-    - app/controllers/profiles_controller.rb

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,39 +1,8 @@
 # frozen_string_literal: true
 
 class ProfilesController < ApplicationController
-  $units = {access: "Access Services",
-            archives: "Archives",
-            bib: "Cataloguing Strategies",
-            collections: "Collection Strategies",
-            copyright: "Copyright",
-            digital: "Digital Production & Preservation Services",
-            digrepo: "Digital Repository & Data Services",
-            dsc: "Digital Scholarship Centre",
-            facilities: "Facilities",
-            health: "Faculty Engagement (Health Sciences)",
-            science: "Faculty Engagement (Natural + Applied Sciences)",
-            humanities: "Faculty Engagement (Social Sciences + Humanities)",
-            iss: "Information Services & User Engagement",
-            admin: "Library Administration",
-            lad: "Library Application Development",
-            las: "Library Application Support",
-            metadata: "Metadata Strategies",
-            open: "Open Publishing & Digitization Services",
-            rdm: "Research Data Management",
-            researchimpact: "Research Impact",
-            its: "Specialized Technical Support",
-            special: "Special Collections",
-            stratigic: "Strategic Partnerships",
-            tl: "Teaching & Learning",
-            ux: "User Experience"}
-  $buildings = {augustana: "Augustana Campus Library",
-                bsj: "Bibliothèque Saint-Jean",
-                bpsc: "Bruce Peel Special Collections",
-                cameron: "Cameron Library",
-                sperber: "Sperber Library",
-                rcrf: "Research & Collections Resource Facility",
-                rutherford: "Rutherford Library",
-                stjosephs: "St. Joseph's Library"}
+  before_action :set_units, only: [:index, :show, :new, :edit]
+  before_action :set_buildings, only: [:index, :show, :new, :edit]
 
   # You'll have to define "cmsPassword" in secrets.yml, or this will fail. Thanks, ansible.
   http_basic_authenticate_with name: Rails.application.secrets.cms_user, password: Rails.application.secrets.cms_password, except: [:index, :show]
@@ -42,14 +11,14 @@ class ProfilesController < ApplicationController
     path = request.url
     if path.include? "unit"
       @unit = params[:unit]
-      @unitname = $units[params[:unit].to_sym]
+      @unitname = @units[params[:unit].to_sym]
       @allunit = Profile.where(unit: @unit)
       @heads = @allunit.where(opt_in: true).order(:last_name)
       @staff = @allunit.where(opt_in: nil).order(:last_name)
       @profiles = @heads + @staff
     elsif path.include? "building"
       @building = params[:building]
-      @buildingname = $buildings[params[:building].to_sym]
+      @buildingname = @buildings[params[:building].to_sym]
       @profiles = Profile.where("campus_address=?", params[:building]).order(:first_name)
     else
       @profiles = Profile.order(:first_name)
@@ -66,14 +35,10 @@ class ProfilesController < ApplicationController
 
   def new
     @profile = Profile.new
-    @buildings = $buildings
-    @units = $units
   end
 
   def edit
     @profile = Profile.friendly.find(params[:id])
-    @buildings = $buildings
-    @units = $units
   end
 
   def create
@@ -103,5 +68,44 @@ class ProfilesController < ApplicationController
 
   def profile_params
     params.require(:profile).permit(:first_name, :last_name, :job_title, :unit, :email, :phone, :campus_address, :expertise, :introduction, :publications, :staff_since, :liason, :links, :orcid, :committees, :personal_interests, :opt_in)
+  end
+
+  def set_buildings
+    @buildings = {augustana: "Augustana Campus Library",
+                  bsj: "Bibliothèque Saint-Jean",
+                  bpsc: "Bruce Peel Special Collections",
+                  cameron: "Cameron Library",
+                  sperber: "Sperber Library",
+                  rcrf: "Research & Collections Resource Facility",
+                  rutherford: "Rutherford Library",
+                  stjosephs: "St. Joseph's Library"}
+  end
+
+  def set_units
+    @units = {access: "Access Services",
+              archives: "Archives",
+              bib: "Cataloguing Strategies",
+              collections: "Collection Strategies",
+              copyright: "Copyright",
+              digital: "Digital Production & Preservation Services",
+              digrepo: "Digital Repository & Data Services",
+              dsc: "Digital Scholarship Centre",
+              facilities: "Facilities",
+              health: "Faculty Engagement (Health Sciences)",
+              science: "Faculty Engagement (Natural + Applied Sciences)",
+              humanities: "Faculty Engagement (Social Sciences + Humanities)",
+              iss: "Information Services & User Engagement",
+              admin: "Library Administration",
+              lad: "Library Application Development",
+              las: "Library Application Support",
+              metadata: "Metadata Strategies",
+              open: "Open Publishing & Digitization Services",
+              rdm: "Research Data Management",
+              researchimpact: "Research Impact",
+              its: "Specialized Technical Support",
+              special: "Special Collections",
+              stratigic: "Strategic Partnerships",
+              tl: "Teaching & Learning",
+              ux: "User Experience"}
   end
 end

--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -20,7 +20,7 @@
         %li
           %a.dropdown-item{"href" => "/staff"}
             ALL STAFF
-        - $units.each_with_index do |(key, value), index|
+        - @units.each_with_index do |(key, value), index|
           %li
             %a.dropdown-item{"href" => "/staff/?unit="+"#{key}"}
               = "#{value}"
@@ -60,13 +60,13 @@
             %span.hidden
               = profile.last_name
           %td.hidden-xs.ual-unit
-            = link_to($units[profile.unit.to_sym], "/staff/?unit="+profile.unit)
+            = link_to(@units[profile.unit.to_sym], "/staff/?unit="+profile.unit)
           %td.hidden-xs.ual-email
             %a{ :href => "tel:#{profile.phone}"}
               = profile.phone
             %p
               = mail_to profile.email, profile.email
-          %td.hidden-xs      
-            = link_to($buildings[profile.campus_address.to_sym], "/locations/"+profile.campus_address) 
-   
+          %td.hidden-xs
+            = link_to(@buildings[profile.campus_address.to_sym], "/locations/"+profile.campus_address)
+
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,6 +1,6 @@
 .a-profile.extra-top-margin
   = link_to profiles_path, class: "staff-back" do
-    <span class="glyphicon glyphicon-chevron-left"></span>  All Staff	
+    <span class="glyphicon glyphicon-chevron-left"></span>  All Staff
   - @photo_link = "https://www2.library.ualberta.ca/2015assets/all-staff-photos/#{@profile.first_name.downcase}-#{@profile.last_name.downcase}.jpg"
   = image_tag(@photo_link, :class=>"a-photo img-responsive")
   %h2.fn
@@ -18,14 +18,14 @@
       = link_to @profile.phone, "tel:"+@profile.phone
     %span.adr
       %span.street-address
-        Building: 
-        = link_to($buildings[@profile.campus_address.to_sym], "/locations/"+@profile.campus_address)
+        Building:
+        = link_to(@buildings[@profile.campus_address.to_sym], "/locations/"+@profile.campus_address)
   %ul
     -if @profile.unit.presence
       %li.unit
         %h4.inline
           Unit:
-        = link_to($units[@profile.unit.to_sym], "/staff/?unit="+@profile.unit)   
+        = link_to(@units[@profile.unit.to_sym], "/staff/?unit="+@profile.unit)
     -if @profile.expertise.presence
       %li.expertise
         %h4.inline


### PR DESCRIPTION
When I added rubocop, I had to TODO exclude the Global Var cop due to our usage of global vars in the profile controller.

Global vars are quite dangerous in nature and their usage should probably be limited. So an easy alternative is instead just write this smarter using simple instance vars.

This PR refactors the profiles controller to use a couple `before_action` methods to set these instance vars instead of resorting to global vars.