### PR TITLE
Bump nodejs to latest version in v18 series

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.1.4
-nodejs 18.15.0
+nodejs 18.20.4
 yarn 1.22.19


### PR DESCRIPTION
Quick PR just to bump our nodejs version to the latest in the v18 series (as this is what Neil will deploy to prod and will be using in CI, etc. Also includes more security fixes etc).