### PR TITLE
Rack v3.1.18 to address CVE-2025-61780 & CVE-2025-61919

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.2)
+    rack (3.1.18)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
Rack v3.1.18 to address 

Security
* [CVE-2025-61780](https://github.com/advisories/GHSA-r657-rxjc-j557) Improper handling of headers in Rack::Sendfile may allow proxy bypass.
* [CVE-2025-61919](https://github.com/advisories/GHSA-6xw4-3v39-52mm) Unbounded read in Rack::Request form parsing can lead to memory exhaustion.



Rack is downgraded to support the future Rails 7.1 to 7.2.2.2 update because [Rails 7.2 actionpack includes the dependance `rack (>= 2.2.4, < 3.2)`](https://github.com/rails/rails/blob/v7.2.2.2/actionpack/actionpack.gemspec#L40) that doesn't support rack 3.2.x.  The [rack v3.1.x versions support the security update](https://github.com/rack/rack/blob/v3.1.18/CHANGELOG.md)