### PR TITLE
Bump mail from 2.8.1 to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,8 @@ GEM
     loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.0)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -199,7 +200,7 @@ GEM
     msgpack (1.8.0)
     mysql2 (0.5.7)
       bigdecimal
-    net-imap (0.5.9)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -375,7 +376,7 @@ GEM
     temple (0.10.3)
     thor (1.4.0)
     tilt (2.6.0)
-    timeout (0.4.3)
+    timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)


### PR DESCRIPTION
Sourced from mail's releases. https://github.com/mikel/mail/releases/tag/2.9.0