### PR TITLE
Grouped pull requests for minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,24 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+        exclude-patterns:
+          - "rubocop*"
+        update-types:
+          - "minor"
+          - "patch"
+      rubocop:
+        patterns:
+          - "rubocop*"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#example-4-grouped-pull-requests-for-minorpatch-updates-and-no-pull-requests-for-major-updates

Minor and patch version updates for bundler dependencies are grouped into a single pull request.

Interested to see if this makes it easier to manage updates.